### PR TITLE
feat: implement Fastify and TCP server setup with routing and logging

### DIFF
--- a/src/Server/Fastify.ts
+++ b/src/Server/Fastify.ts
@@ -1,0 +1,39 @@
+import Fastify from 'fastify';
+import ServerInfo from '../config/Info';
+import { Port } from '../config/Keys';
+
+// Create a Fastify instance
+const fastify = Fastify({
+  logger: true, // Enable logging
+});
+
+const PORT: number = Number(Port.HTTP) || 27018;
+
+// Define a simple important route
+fastify.get('/', async (_request: any, _reply: any) => {
+  return { message: 'Hello, from AxioDB Docker Container' };
+});
+
+fastify.get('/health', async (_request: any, _reply: any) => {
+  return { status: 'OK' };
+});
+fastify.get('/status', async (_request: any, _reply: any) => {
+  return { status: `Running on port ${PORT}` };
+});
+
+// Define a route to get the version information
+fastify.get('/info', async(_request: any, _reply:any)=> {
+  const { DB_Info, OS_Info, Runtime_Info } = await ServerInfo();
+  return { DB_Info, OS_Info, Runtime_Info };
+})
+// Start the server
+const start = async () => {
+  try {
+    await fastify.listen({ port: PORT, host: '0.0.0.0' });
+    console.log(`Server is running at http://localhost:${PORT}`);
+  } catch (err) {
+    fastify.log.error(err);
+  }
+};
+
+export default start;

--- a/src/Server/TCP.ts
+++ b/src/Server/TCP.ts
@@ -1,0 +1,29 @@
+// Import TCP Server Configuration
+import net from "node:net";
+import { Port } from "../config/Keys";
+const PORT: number = Number(Port.TCP) || 27018;
+
+const server = net.createServer((socket) => {
+    console.log('Client connected');
+
+    socket.on('data', (data) => {
+        console.log('Received from client:', data.toString());
+        socket.write(`Echo: ${data}`);
+    });
+
+    socket.on('end', () => {
+        console.log('Client disconnected');
+    });
+
+    socket.on('error', (err) => {
+        console.error('Socket Error:', err.message);
+    });
+});
+
+const tcpServer = async () => {
+    server.listen(PORT, () => {
+        console.log(`TCP Server listening on port ${PORT}`);
+    });
+}
+
+export default tcpServer;

--- a/src/config/Info.ts
+++ b/src/config/Info.ts
@@ -30,7 +30,6 @@ export default async ()=> {
         OpenSSL_Version: process.versions.openssl,
         Zlib_Version: process.versions.zlib,
         Libuv_Version: process.versions.libuv,
-        WebServer: "Fastify",
         WebServer_Version: versionJson.dependencies.fastify,
     }
     return { DB_Info, OS_Info, Runtime_Info };

--- a/src/config/Keys.ts
+++ b/src/config/Keys.ts
@@ -1,0 +1,6 @@
+export enum Port {
+    HTTP = 27018,
+    TCP = 27019,
+    GRPC = 27020,
+    WEBSOCKET = 27021
+}

--- a/src/config/docker.ts
+++ b/src/config/docker.ts
@@ -1,38 +1,8 @@
-import Fastify from 'fastify';
-import ServerInfo from './Info';
+// Import all Servers
+import start from "../Server/Fastify";
+import tcpServer from "../Server/TCP";
 
-// Create a Fastify instance
-const fastify = Fastify({
-  logger: true, // Enable logging
-});
 
-const PORT: number = Number(process.env.PORT) || 27018;
-
-// Define a simple important route
-fastify.get('/', async (_request: any, _reply: any) => {
-  return { message: 'Hello, from AxioDB Docker Container' };
-});
-
-fastify.get('/health', async (_request: any, _reply: any) => {
-  return { status: 'OK' };
-});
-fastify.get('/status', async (_request: any, _reply: any) => {
-  return { status: `Running on port ${PORT}` };
-});
-
-// Define a route to get the version information
-fastify.get('/info', async(_request: any, _reply:any)=> {
-  const { DB_Info, OS_Info, Runtime_Info } = await ServerInfo();
-  return { DB_Info, OS_Info, Runtime_Info };
-})
-// Start the server
-const start = async () => {
-  try {
-    await fastify.listen({ port: PORT, host: '0.0.0.0' });
-    console.log(`Server is running at http://localhost:${PORT}`);
-  } catch (err) {
-    fastify.log.error(err);
-  }
-};
-
+/// Run the server
 start();
+tcpServer();


### PR DESCRIPTION
This pull request introduces significant changes to the server configuration by modularizing the server setup and adding support for a TCP server. The most important changes include creating separate files for Fastify and TCP server configurations, defining a port enumeration, and updating the Docker configuration to run both servers.

### Server Configuration Enhancements:

* [`src/Server/Fastify.ts`](diffhunk://#diff-9b6c3e3cd362f4ad7bd1d86dfdf62bd4a5fcd70d7cb8b3b5df314ddcf35716eeR1-R39): Created a new file for Fastify server configuration, including routes for root, health, status, and info endpoints.
* [`src/Server/TCP.ts`](diffhunk://#diff-a8408723d82d73a0ed9f638300db7b601366093c189d41d047557824aacb770aR1-R29): Added a new file for TCP server configuration, handling client connections, data reception, and socket errors.

### Configuration Updates:

* [`src/config/Keys.ts`](diffhunk://#diff-2f95fae9608fb412a8cb4efd58600cf2750f36d203426acdb8de59fe87b975beR1-R6): Defined an enumeration for ports used by different server types (HTTP, TCP, GRPC, WEBSOCKET).
* [`src/config/Info.ts`](diffhunk://#diff-31da5425f32fe2c714d9844ff638ff36fcd87fcfc88475a7e2f3b412c5243616L33): Removed the hardcoded `WebServer` string and kept only the `WebServer_Version` from the version JSON.

### Docker Configuration:

* [`src/config/docker.ts`](diffhunk://#diff-a5f0117f2a6f30d3fbc0ae1728d4c9273d467c4abbf81cdbd77fb10a1bcdd58bL1-R8): Updated the Docker configuration to import and start both the Fastify and TCP servers, replacing the previous inline Fastify server setup.