### PR TITLE
fix: update axiodb version to 2.10.15 in package.json and package-loc…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "axiodb-docker",
-  "version": "1.4.11",
+  "version": "1.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "axiodb-docker",
-      "version": "1.4.11",
+      "version": "1.4.13",
       "license": "MIT",
       "dependencies": {
         "@fastify/middie": "^9.0.3",
         "@fastify/rate-limit": "^10.2.2",
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",
-        "axiodb": "^2.9.13",
+        "axiodb": "^2.10.15",
         "bcryptjs": "^3.0.2",
         "fastify": "^5.3.2",
         "nodemon": "^3.1.7",
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/axiodb": {
-      "version": "2.9.13",
-      "resolved": "https://registry.npmjs.org/axiodb/-/axiodb-2.9.13.tgz",
-      "integrity": "sha512-Py5RgqTO9T2juVU/C0R3fW8dHdfT20foiMCVN9prr1iThcC2cnogRLTpJqpa9zWAcZ+BUyqoe92sZpwRh1LEpQ==",
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/axiodb/-/axiodb-2.10.15.tgz",
+      "integrity": "sha512-/7ah3NiI0SGDbZV9wbdcGWPZjePktFystgCz1/18erSbU+v5DX4brcVlXRWI3HaSYf7xJM5B9/6QsDnXX2RFiw==",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "axiodb-docker",
-  "version": "1.4.13",
-  "Published": "28th April 2025",
+  "version": "1.4.14",
+  "Published": "4th May 2025",
   "description": "AxioDB Docker is designed to extend the capabilities of AxioDB, enabling seamless integration with other programming languages and systems via REST APIs, TCP connections, WebSocket, and more. This Docker image provides a scalable and efficient way to deploy AxioDB as a service.",
   "main": "docker.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "@fastify/rate-limit": "^10.2.2",
     "@grpc/grpc-js": "^1.13.3",
     "@grpc/proto-loader": "^0.7.13",
-    "axiodb": "^2.9.13",
+    "axiodb": "^2.10.15",
     "bcryptjs": "^3.0.2",
     "fastify": "^5.3.2",
     "nodemon": "^3.1.7",


### PR DESCRIPTION
This pull request updates the `package.json` file to reflect a new version of the project and updates a dependency to its latest version.

Version and metadata updates:

* Updated the project version from `1.4.13` to `1.4.14` and changed the "Published" date to `4th May 2025`. (`[package.jsonL3-R4](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R4)`)

Dependency updates:

* Upgraded the `axiodb` dependency from version `^2.9.13` to `^2.10.15`. (`[package.jsonL36-R36](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R36)`)…k.json